### PR TITLE
fix: 알림 로그 중복 생성 않도록 수정#18

### DIFF
--- a/src/main/java/com/notificationserver/application/port/out/dto/NotificationSendOutDto.java
+++ b/src/main/java/com/notificationserver/application/port/out/dto/NotificationSendOutDto.java
@@ -17,9 +17,9 @@ public class NotificationSendOutDto {
 		this.content = content;
 	}
 
-	public static NotificationSendOutDto getNotification(Notification notification) {
+	public static NotificationSendOutDto getNotification(Notification notification, String fcmToken) {
 		return NotificationSendOutDto.builder()
-				.fcmToken(notification.getFcmToken())
+				.fcmToken(fcmToken)
 				.title(notification.getTitle())
 				.content(notification.getContent())
 				.build();

--- a/src/main/java/com/notificationserver/domain/Notification.java
+++ b/src/main/java/com/notificationserver/domain/Notification.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 public class Notification {
 
 	private Long notificationLogId;
-	private String fcmToken;
 	private String uuid;
 	private LocalDateTime notificationCreateAt;
 	private String content;
@@ -22,10 +21,9 @@ public class Notification {
 	private Integer readStatus;
 	private LocalDateTime notificationLogCreateAt;
 
-	public static Notification sendAlarm(String fcmToken, SaveNotificationLogInDto dto) {
+	public static Notification sendAlarm(SaveNotificationLogInDto dto) {
 		return Notification.builder()
 				.uuid(dto.getUuid())
-				.fcmToken(fcmToken)
 				.content(dto.getContent())
 				.title(dto.getTitle())
 				.readStatus(dto.getReadStatus())


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->
#18 
- 기존 알림 생성 시 회원의 FCM 토큰마다 알림 로그 생성
- 알림은 하나만 생성하도록 수정 완료했습니다. 

